### PR TITLE
Consolidate PR sorting into fetchPullRequests

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -136,7 +136,7 @@ func fetchPullRequests(queryString string, limit int) ([]RepositoryItem, error) 
 	for _, name := range repoMap {
 		prs := name.PullRequestItems
 		sort.Slice(prs, func(i, j int) bool {
-			return prs[i].Number < prs[j].Number
+			return prs[i].Number > prs[j].Number
 		})
 	}
 

--- a/printer.go
+++ b/printer.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"sort"
 )
 
 func (pri *PullRequestItem) printLine(numberWidth int, authorWidth, updatedAtWidth int, formatter Formatter) {
@@ -36,12 +35,8 @@ func (ri *RepositoryItem) printList(opts *Options) {
 	}
 
 	fmt.Printf("# %s\n", formatter.FormatRepositoryName(ri.Name))
-	prs := ri.PullRequestItems
-	sort.Slice(prs, func(i, j int) bool {
-		return prs[i].Number > prs[j].Number
-	})
 
-	for _, pr := range prs {
+	for _, pr := range ri.PullRequestItems {
 		pr.printLine(numberWidth, authorWidth, updatedAtWidth, formatter)
 	}
 }


### PR DESCRIPTION
## Summary
- `fetchPullRequests` (fetch.go) sorted PRs ascending, then `printList` (printer.go) re-sorted the same slice descending, mutating the caller's data as a side effect of a print function.
- Interactive mode skipped `printList`, so it displayed PRs in a different order (ascending) than non-interactive mode (descending) — an inconsistency caused by the duplicated sort.
- Sorting responsibility is now consolidated in `fetchPullRequests`, ordering PRs by Number descending (matching prior non-interactive output), and the destructive re-sort in `printList` is removed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Ran the built binary against the `codefirst` org and confirmed PRs are listed in descending Number order per repository