### PR TITLE
Remove hidden side effect from formatQueryString

### DIFF
--- a/command.go
+++ b/command.go
@@ -77,6 +77,9 @@ func run(orgs []string, opts *Options) error {
 		go func(i int, org string) {
 			defer wg.Done()
 			queryString := formatQueryString(org, opts)
+			if opts.Verbose {
+				fmt.Printf("query: %s\n", queryString)
+			}
 			repositories, err := fetchPullRequests(queryString, opts.Limit)
 			results[i] = result{repositories: repositories, err: err}
 		}(i, org)

--- a/fetch.go
+++ b/fetch.go
@@ -98,10 +98,6 @@ func formatQueryString(org string, opts *Options) string {
 		queryString += fmt.Sprintf(" %s", query)
 	}
 
-	if opts.Verbose {
-		fmt.Printf("query: %s\n", queryString)
-	}
-
 	return queryString
 }
 


### PR DESCRIPTION
## Summary
- `formatQueryString` looked like a pure query-string builder but also called `fmt.Printf` when `opts.Verbose` was set, so its name didn't match its behavior and the verbose output couldn't be tested.
- Moved the verbose logging to the caller (`command.go`, where `fetchPullRequests` is invoked), keeping `formatQueryString` a pure function.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Ran the built binary with `--verbose` against the `codefirst` org and confirmed the `query: ...` line is still printed