### PR TITLE
Extract grouping and sorting from fetchPullRequests into a pure function

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -117,26 +117,33 @@ func fetchPullRequests(queryString string, limit int) ([]RepositoryItem, error) 
 		return []RepositoryItem{}, err
 	}
 
-	repoMap := map[string]RepositoryItem{}
+	pullRequests := make([]PullRequest, 0, len(query.Nodes))
 	for _, node := range query.Nodes {
-		pr := node.PullRequest
-		if _, ok := repoMap[pr.Repository.NameWithOwner]; !ok {
-			repoMap[pr.Repository.NameWithOwner] = RepositoryItem{Name: pr.Repository.NameWithOwner, PullRequestItems: []PullRequestItem{}}
-		}
-		pullRequestItems := append(repoMap[pr.Repository.NameWithOwner].PullRequestItems, pr.toPullRequestItem())
-		repositoryItem := RepositoryItem{Name: pr.Repository.NameWithOwner, PullRequestItems: pullRequestItems}
-		repoMap[pr.Repository.NameWithOwner] = repositoryItem
+		pullRequests = append(pullRequests, node.PullRequest)
 	}
 
-	// sort pull requests in each repositories
-	for _, name := range repoMap {
-		prs := name.PullRequestItems
-		sort.Slice(prs, func(i, j int) bool {
-			return prs[i].Number > prs[j].Number
+	return groupAndSortPullRequests(pullRequests), nil
+}
+
+// groupAndSortPullRequests groups pull requests by repository, sorts pull
+// requests within each repository by Number descending, and sorts
+// repositories by name.
+func groupAndSortPullRequests(pullRequests []PullRequest) []RepositoryItem {
+	repoMap := map[string]RepositoryItem{}
+	for _, pr := range pullRequests {
+		name := pr.Repository.NameWithOwner
+		repo := repoMap[name]
+		repo.Name = name
+		repo.PullRequestItems = append(repo.PullRequestItems, pr.toPullRequestItem())
+		repoMap[name] = repo
+	}
+
+	for _, repo := range repoMap {
+		sort.Slice(repo.PullRequestItems, func(i, j int) bool {
+			return repo.PullRequestItems[i].Number > repo.PullRequestItems[j].Number
 		})
 	}
 
-	// get sorted repositories
 	repoNames := make([]string, 0, len(repoMap))
 	for name := range repoMap {
 		repoNames = append(repoNames, name)
@@ -148,5 +155,5 @@ func fetchPullRequests(queryString string, limit int) ([]RepositoryItem, error) 
 		repositories = append(repositories, repoMap[name])
 	}
 
-	return repositories, nil
+	return repositories
 }

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -280,6 +280,48 @@ func TestToPullRequestItem(t *testing.T) {
 	}
 }
 
+func TestGroupAndSortPullRequests(t *testing.T) {
+	newPR := func(repo string, number int) PullRequest {
+		pr := PullRequest{Number: number}
+		pr.Repository.NameWithOwner = repo
+		return pr
+	}
+
+	pullRequests := []PullRequest{
+		newPR("org/b", 1),
+		newPR("org/a", 3),
+		newPR("org/a", 1),
+		newPR("org/a", 2),
+	}
+
+	repositories := groupAndSortPullRequests(pullRequests)
+
+	if len(repositories) != 2 {
+		t.Fatalf("len(repositories) = %d, want 2", len(repositories))
+	}
+
+	if repositories[0].Name != "org/a" {
+		t.Errorf("repositories[0].Name = %q, want %q", repositories[0].Name, "org/a")
+	}
+	if repositories[1].Name != "org/b" {
+		t.Errorf("repositories[1].Name = %q, want %q", repositories[1].Name, "org/b")
+	}
+
+	gotNumbers := make([]int, 0, len(repositories[0].PullRequestItems))
+	for _, pr := range repositories[0].PullRequestItems {
+		gotNumbers = append(gotNumbers, pr.Number)
+	}
+	wantNumbers := []int{3, 2, 1}
+	if len(gotNumbers) != len(wantNumbers) {
+		t.Fatalf("numbers = %v, want %v", gotNumbers, wantNumbers)
+	}
+	for i := range wantNumbers {
+		if gotNumbers[i] != wantNumbers[i] {
+			t.Errorf("numbers = %v, want %v", gotNumbers, wantNumbers)
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
## Summary
- `fetchPullRequests` mixed API client creation, query execution, per-repository grouping, and sorting in a single function. Because the client was created inside the function, it couldn't be mocked, so `fetch_test.go` had no coverage for the grouping/sorting logic.
- Extracted the grouping and sorting logic into a new pure function, `groupAndSortPullRequests([]PullRequest) []RepositoryItem`, which is now unit-tested directly. `fetchPullRequests` is left responsible only for the GraphQL call and handing its results to the pure function.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (added `TestGroupAndSortPullRequests` covering grouping by repo, per-repo Number-descending sort, and repo-name sort)
- [x] Ran the built binary against the `codefirst` org and confirmed output is unchanged