### PR TITLE
Guard type assertion in interactive mode to avoid panic on empty selection

### DIFF
--- a/interactive.go
+++ b/interactive.go
@@ -37,7 +37,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if key.Matches(msg, m.keys.openWithBrowser) {
-			_ = browser.OpenURL(m.list.SelectedItem().(listItem).pullRequestItem.Url)
+			if item, ok := m.list.SelectedItem().(listItem); ok {
+				_ = browser.OpenURL(item.pullRequestItem.Url)
+			}
 			return m, nil
 		}
 	case tea.WindowSizeMsg:


### PR DESCRIPTION
## Summary
- `m.list.SelectedItem().(listItem)` panics when `SelectedItem()` returns nil (e.g. interactive mode launched with zero search results)
- Use the `ok`-checked form and no-op when the assertion fails

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`