### PR TITLE
Change Options.Excludes and AdditionalQueries from *[]string to []string

### DIFF
--- a/command.go
+++ b/command.go
@@ -12,16 +12,16 @@ import (
 type Options struct {
 	Version           bool
 	Limit             int
-	Excludes          *[]string
+	Excludes          []string
 	Author            string
-	AdditionalQueries *[]string
+	AdditionalQueries []string
 	Verbose           bool
 	Interactive       bool
 	NoColor           bool
 }
 
 func rootCmd() *cobra.Command {
-	opts := &Options{Excludes: &[]string{}, AdditionalQueries: &[]string{}}
+	opts := &Options{}
 	cmd := &cobra.Command{
 		Use:   "gh list-prs <org> [<org>...]",
 		Short: "List PRs for one or more orgs",
@@ -44,10 +44,10 @@ func rootCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.Version, "version", false, "show version")
-	cmd.Flags().StringArrayVarP(opts.Excludes, "exclude", "e", []string{}, "exclude repositories")
+	cmd.Flags().StringArrayVarP(&opts.Excludes, "exclude", "e", []string{}, "exclude repositories")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "l", 50, "Max number of search results in all repository")
 	cmd.Flags().StringVarP(&opts.Author, "author", "a", "", "Filter by author")
-	cmd.Flags().StringArrayVarP(opts.AdditionalQueries, "additional-query", "q", []string{}, "additional query")
+	cmd.Flags().StringArrayVarP(&opts.AdditionalQueries, "additional-query", "q", []string{}, "additional query")
 	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVarP(&opts.Interactive, "interactive", "i", false, "interactive mode")
 	cmd.Flags().BoolVar(&opts.NoColor, "no-color", false, "disable color output and show plain URLs")

--- a/fetch.go
+++ b/fetch.go
@@ -84,7 +84,7 @@ type PullRequestItem struct {
 
 func formatQueryString(org string, opts *Options) string {
 	queryString := fmt.Sprintf("is:open is:pr archived:false org:%s", org)
-	for _, exclude := range *opts.Excludes {
+	for _, exclude := range opts.Excludes {
 		if strings.Contains(exclude, "/") {
 			queryString += fmt.Sprintf(" -repo:%s", exclude)
 		} else {
@@ -94,7 +94,7 @@ func formatQueryString(org string, opts *Options) string {
 	if opts.Author != "" {
 		queryString += fmt.Sprintf(" author:%s", opts.Author)
 	}
-	for _, query := range *opts.AdditionalQueries {
+	for _, query := range opts.AdditionalQueries {
 		queryString += fmt.Sprintf(" %s", query)
 	}
 

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -17,10 +17,10 @@ func TestFormatQueryString(t *testing.T) {
 			name: "basic query",
 			org:  "myorg",
 			opts: &Options{
-				Excludes:           &[]string{},
-				AdditionalQueries:  &[]string{},
-				Author:             "",
-				Verbose:            false,
+				Excludes:          []string{},
+				AdditionalQueries: []string{},
+				Author:            "",
+				Verbose:           false,
 			},
 			wantContains: []string{
 				"is:open",
@@ -34,8 +34,8 @@ func TestFormatQueryString(t *testing.T) {
 			name: "with excludes",
 			org:  "myorg",
 			opts: &Options{
-				Excludes:          &[]string{"repo1", "org2/repo2"},
-				AdditionalQueries: &[]string{},
+				Excludes:          []string{"repo1", "org2/repo2"},
+				AdditionalQueries: []string{},
 				Author:            "",
 				Verbose:           false,
 			},
@@ -50,8 +50,8 @@ func TestFormatQueryString(t *testing.T) {
 			name: "with author",
 			org:  "myorg",
 			opts: &Options{
-				Excludes:          &[]string{},
-				AdditionalQueries: &[]string{},
+				Excludes:          []string{},
+				AdditionalQueries: []string{},
 				Author:            "alice",
 				Verbose:           false,
 			},
@@ -65,8 +65,8 @@ func TestFormatQueryString(t *testing.T) {
 			name: "with additional queries",
 			org:  "myorg",
 			opts: &Options{
-				Excludes:          &[]string{},
-				AdditionalQueries: &[]string{"label:bug", "state:draft"},
+				Excludes:          []string{},
+				AdditionalQueries: []string{"label:bug", "state:draft"},
 				Author:            "",
 				Verbose:           false,
 			},
@@ -81,8 +81,8 @@ func TestFormatQueryString(t *testing.T) {
 			name: "with all options",
 			org:  "myorg",
 			opts: &Options{
-				Excludes:          &[]string{"repo1", "org2/repo2"},
-				AdditionalQueries: &[]string{"label:bug"},
+				Excludes:          []string{"repo1", "org2/repo2"},
+				AdditionalQueries: []string{"label:bug"},
 				Author:            "bob",
 				Verbose:           false,
 			},
@@ -128,12 +128,12 @@ func TestToPullRequestItem(t *testing.T) {
 		{
 			name: "PR with status check",
 			pr: &PullRequest{
-				Number: 123,
-				Title:  "Fix bug",
-				Url:    "https://github.com/test/repo/pull/123",
-				UpdatedAt: time.Date(2024, 11, 30, 12, 0, 0, 0, time.UTC),
-				IsDraft: false,
-				Author: struct{ Login string }{Login: "alice"},
+				Number:     123,
+				Title:      "Fix bug",
+				Url:        "https://github.com/test/repo/pull/123",
+				UpdatedAt:  time.Date(2024, 11, 30, 12, 0, 0, 0, time.UTC),
+				IsDraft:    false,
+				Author:     struct{ Login string }{Login: "alice"},
 				Repository: struct{ NameWithOwner string }{NameWithOwner: "test/repo"},
 				Commits: Commits{
 					Nodes: []struct {
@@ -173,12 +173,12 @@ func TestToPullRequestItem(t *testing.T) {
 		{
 			name: "PR without status check",
 			pr: &PullRequest{
-				Number: 456,
-				Title:  "Add feature",
-				Url:    "https://github.com/test/repo/pull/456",
-				UpdatedAt: time.Date(2024, 11, 30, 13, 0, 0, 0, time.UTC),
-				IsDraft: true,
-				Author: struct{ Login string }{Login: "bob"},
+				Number:     456,
+				Title:      "Add feature",
+				Url:        "https://github.com/test/repo/pull/456",
+				UpdatedAt:  time.Date(2024, 11, 30, 13, 0, 0, 0, time.UTC),
+				IsDraft:    true,
+				Author:     struct{ Login string }{Login: "bob"},
 				Repository: struct{ NameWithOwner string }{NameWithOwner: "test/repo"},
 				Commits: Commits{
 					Nodes: []struct {
@@ -204,12 +204,12 @@ func TestToPullRequestItem(t *testing.T) {
 		{
 			name: "PR with failure check status",
 			pr: &PullRequest{
-				Number: 789,
-				Title:  "WIP",
-				Url:    "https://github.com/test/repo/pull/789",
-				UpdatedAt: time.Date(2024, 11, 30, 14, 0, 0, 0, time.UTC),
-				IsDraft: false,
-				Author: struct{ Login string }{Login: "charlie"},
+				Number:     789,
+				Title:      "WIP",
+				Url:        "https://github.com/test/repo/pull/789",
+				UpdatedAt:  time.Date(2024, 11, 30, 14, 0, 0, 0, time.UTC),
+				IsDraft:    false,
+				Author:     struct{ Login string }{Login: "charlie"},
 				Repository: struct{ NameWithOwner string }{NameWithOwner: "test/repo"},
 				Commits: Commits{
 					Nodes: []struct {


### PR DESCRIPTION
## Summary
- `Options.Excludes` and `Options.AdditionalQueries` were `*[]string`, requiring dereference (`*opts.Excludes`) at call sites for no benefit
- Changed both fields to plain `[]string`, passing `&opts.Excludes` / `&opts.AdditionalQueries` to cobra's `StringArrayVarP` instead

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`