### PR TITLE
Rename query type to searchQuery to avoid shadowing

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -61,7 +61,7 @@ type Search struct {
 	}
 }
 
-type query struct {
+type searchQuery struct {
 	Search `graphql:"search(first: $first, type: ISSUE, query: $query)"`
 }
 
@@ -107,7 +107,7 @@ func fetchPullRequests(queryString string, limit int) ([]RepositoryItem, error) 
 		return []RepositoryItem{}, err
 	}
 
-	var query = query{}
+	var query = searchQuery{}
 	variables := map[string]interface{}{
 		"first": graphql.Int(limit),
 		"query": graphql.String(queryString),


### PR DESCRIPTION
## Summary
- `var query = query{}` in `fetchPullRequests` shadowed the `query` type with a `query` variable of the same name, confusing readers
- Renamed the type to `searchQuery`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`