### PR TITLE
Respect --no-color in interactive mode

### DIFF
--- a/command.go
+++ b/command.go
@@ -96,7 +96,7 @@ func run(orgs []string, opts *Options) error {
 	}
 
 	if opts.Interactive {
-		if err := printResultInteractive(orgs, allRepositories); err != nil {
+		if err := printResultInteractive(orgs, allRepositories, opts.NoColor); err != nil {
 			return err
 		}
 	} else {

--- a/interactive.go
+++ b/interactive.go
@@ -11,11 +11,11 @@ import (
 
 type listItem struct {
 	pullRequestItem PullRequestItem
+	formatter       Formatter
 }
 
 func (li listItem) Title() string {
-	formatter := NewFormatter(false)
-	return fmt.Sprintf("%s #%d @%s %s %s", li.pullRequestItem.RepositoryName, li.pullRequestItem.Number, li.pullRequestItem.Author, formatter.FormatCheckStatus(&li.pullRequestItem), formatter.FormatReviewDecision(&li.pullRequestItem))
+	return fmt.Sprintf("%s #%d @%s %s %s", li.pullRequestItem.RepositoryName, li.pullRequestItem.Number, li.pullRequestItem.Author, li.formatter.FormatCheckStatus(&li.pullRequestItem), li.formatter.FormatReviewDecision(&li.pullRequestItem))
 }
 func (li listItem) Description() string { return li.pullRequestItem.Title }
 func (li listItem) FilterValue() string {
@@ -66,11 +66,12 @@ func newListKeyMap() *listKeyMap {
 	}
 }
 
-func printResultInteractive(orgs []string, repositories []RepositoryItem) error {
+func printResultInteractive(orgs []string, repositories []RepositoryItem, noColor bool) error {
+	formatter := NewFormatter(noColor)
 	items := []list.Item{}
 	for _, repo := range repositories {
 		for _, pr := range repo.PullRequestItems {
-			items = append(items, listItem{pullRequestItem: pr})
+			items = append(items, listItem{pullRequestItem: pr, formatter: formatter})
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `printResultInteractive` now takes `noColor` and builds the formatter from `opts.NoColor`, instead of hardcoding `NewFormatter(false)`
- `listItem` holds a single shared `Formatter` instead of creating a new one on every `Title()` render

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Verified with a temporary test that `Title()` output has ANSI codes when noColor=false and none when noColor=true