### PR TITLE
Group column widths into a struct in printer.go

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -4,39 +4,43 @@ import (
 	"fmt"
 )
 
-func (pri *PullRequestItem) printLine(numberWidth int, authorWidth, updatedAtWidth int, formatter Formatter) {
+type columnWidths struct {
+	number    int
+	author    int
+	updatedAt int
+}
+
+func (pri *PullRequestItem) printLine(widths columnWidths, formatter Formatter) {
 	numberString := formatter.FormatPRNumber(pri)
-	numberPadding := numberWidth - len(fmt.Sprintf("#%d", pri.Number))
+	numberPadding := widths.number - len(fmt.Sprintf("#%d", pri.Number))
 	login := formatter.FormatAuthor(pri)
 	updatedAt := formatter.FormatUpdatedAt(pri)
 	title := formatter.FormatTitle(pri)
 	statusSymbol := formatter.FormatCheckStatus(pri)
 	reviewDecision := formatter.FormatReviewDecision(pri)
 
-	fmt.Printf("%s%-*s%-*s %-*s %s %s %s\n", numberString, numberPadding+1, "", authorWidth, login, updatedAtWidth, updatedAt, title, statusSymbol, reviewDecision)
+	fmt.Printf("%s%-*s%-*s %-*s %s %s %s\n", numberString, numberPadding+1, "", widths.author, login, widths.updatedAt, updatedAt, title, statusSymbol, reviewDecision)
 }
 
 func (ri *RepositoryItem) printList(opts *Options) {
 	formatter := NewFormatter(opts.NoColor)
 
-	numberWidth := 0
-	authorWidth := 0
-	updatedAtWidth := len("2006-01-02")
+	widths := columnWidths{updatedAt: len("2006-01-02")}
 	for _, pr := range ri.PullRequestItems {
 		nWidth := len(fmt.Sprintf("#%d", pr.Number))
-		if nWidth > numberWidth {
-			numberWidth = nWidth
+		if nWidth > widths.number {
+			widths.number = nWidth
 		}
 
 		aWidth := len(pr.Author)
-		if aWidth > authorWidth {
-			authorWidth = aWidth
+		if aWidth > widths.author {
+			widths.author = aWidth
 		}
 	}
 
 	fmt.Printf("# %s\n", formatter.FormatRepositoryName(ri.Name))
 
 	for _, pr := range ri.PullRequestItems {
-		pr.printLine(numberWidth, authorWidth, updatedAtWidth, formatter)
+		pr.printLine(widths, formatter)
 	}
 }


### PR DESCRIPTION
## Summary
- `printLine` took `numberWidth`, `authorWidth`, `updatedAtWidth` as three separate int params (a data clump); grouped them into a `columnWidths` struct passed as a single value

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Manually verified `printList` output formatting (column alignment) is unchanged