### PR TITLE
Rename groceryList to prList in interactive.go

### DIFF
--- a/interactive.go
+++ b/interactive.go
@@ -76,18 +76,18 @@ func printResultInteractive(orgs []string, repositories []RepositoryItem, noColo
 	}
 
 	listKeys := newListKeyMap()
-	groceryList := list.New(items, list.NewDefaultDelegate(), 0, 0)
-	groceryList.AdditionalFullHelpKeys = func() []key.Binding {
+	prList := list.New(items, list.NewDefaultDelegate(), 0, 0)
+	prList.AdditionalFullHelpKeys = func() []key.Binding {
 		return []key.Binding{
 			listKeys.openWithBrowser,
 		}
 	}
-	groceryList.AdditionalShortHelpKeys = func() []key.Binding {
+	prList.AdditionalShortHelpKeys = func() []key.Binding {
 		return []key.Binding{
 			listKeys.openWithBrowser,
 		}
 	}
-	m := model{list: groceryList, keys: listKeys}
+	m := model{list: prList, keys: listKeys}
 	if len(orgs) == 1 {
 		m.list.Title = fmt.Sprintf("PRs in %s", orgs[0])
 	} else {


### PR DESCRIPTION
## Summary
- `groceryList` was leftover naming copied from the bubbles list example; renamed to `prList` since it holds the PR list items

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`