### PR TITLE
Use strings.Contains instead of a hand-rolled contains helper in fetch_test.go

### DIFF
--- a/fetch_test.go
+++ b/fetch_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -105,13 +106,13 @@ func TestFormatQueryString(t *testing.T) {
 			result := formatQueryString(tt.org, tt.opts)
 
 			for _, want := range tt.wantContains {
-				if !contains(result, want) {
+				if !strings.Contains(result, want) {
 					t.Errorf("formatQueryString() = %q, want to contain %q", result, want)
 				}
 			}
 
 			for _, notWant := range tt.wantNotContain {
-				if contains(result, notWant) {
+				if strings.Contains(result, notWant) {
 					t.Errorf("formatQueryString() = %q, should not contain %q", result, notWant)
 				}
 			}
@@ -320,13 +321,4 @@ func TestGroupAndSortPullRequests(t *testing.T) {
 			t.Errorf("numbers = %v, want %v", gotNumbers, wantNumbers)
 		}
 	}
-}
-
-func contains(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
- `fetch_test.go` reimplemented substring search with a hand-written `contains` loop, while `formatter_test.go` in the same package already used `strings.Contains`; replaced the two call sites and removed the now-unused helper for consistency

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`