### PR TITLE
Extract check status / review decision magic strings into constants

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -10,6 +10,15 @@ import (
 	graphql "github.com/cli/shurcooL-graphql"
 )
 
+const (
+	checkStatusSuccess = "SUCCESS"
+	checkStatusFailure = "FAILURE"
+	checkStatusPending = "PENDING"
+	checkStatusUnknown = "UNKNOWN"
+)
+
+const reviewDecisionApproved = "APPROVED"
+
 type Commits struct {
 	Nodes []struct {
 		Commit struct {
@@ -37,7 +46,7 @@ type PullRequest struct {
 }
 
 func (pr *PullRequest) toPullRequestItem() PullRequestItem {
-	checkStatus := "PENDING"
+	checkStatus := checkStatusUnknown
 	if len(pr.Commits.Nodes) > 0 {
 		checkStatus = pr.Commits.Nodes[0].Commit.StatusCheckRollup.State
 	}

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -172,7 +172,7 @@ func TestToPullRequestItem(t *testing.T) {
 			},
 		},
 		{
-			name: "PR without status check",
+			name: "PR without commit info",
 			pr: &PullRequest{
 				Number:     456,
 				Title:      "Add feature",
@@ -199,7 +199,7 @@ func TestToPullRequestItem(t *testing.T) {
 				IsDraft:        true,
 				Url:            "https://github.com/test/repo/pull/456",
 				RepositoryName: "test/repo",
-				CheckStatus:    "PENDING",
+				CheckStatus:    checkStatusUnknown,
 			},
 		},
 		{

--- a/formatter.go
+++ b/formatter.go
@@ -53,11 +53,11 @@ func (cf *ColorFormatter) FormatTitle(pri *PullRequestItem) string {
 
 func (cf *ColorFormatter) FormatCheckStatus(pri *PullRequestItem) string {
 	switch pri.CheckStatus {
-	case "SUCCESS":
+	case checkStatusSuccess:
 		return aurora.Green("✔").String()
-	case "FAILURE":
+	case checkStatusFailure:
 		return aurora.Red("✘").String()
-	case "PENDING":
+	case checkStatusPending:
 		return "⏳"
 	default:
 		return ""
@@ -65,7 +65,7 @@ func (cf *ColorFormatter) FormatCheckStatus(pri *PullRequestItem) string {
 }
 
 func (cf *ColorFormatter) FormatReviewDecision(pri *PullRequestItem) string {
-	if pri.ReviewDecision == "APPROVED" {
+	if pri.ReviewDecision == reviewDecisionApproved {
 		return aurora.Magenta("✓").String()
 	}
 	return ""
@@ -100,11 +100,11 @@ func (ncf *NoColorFormatter) FormatTitle(pri *PullRequestItem) string {
 
 func (ncf *NoColorFormatter) FormatCheckStatus(pri *PullRequestItem) string {
 	switch pri.CheckStatus {
-	case "SUCCESS":
+	case checkStatusSuccess:
 		return "✔"
-	case "FAILURE":
+	case checkStatusFailure:
 		return "✘"
-	case "PENDING":
+	case checkStatusPending:
 		return "⏳"
 	default:
 		return ""
@@ -112,7 +112,7 @@ func (ncf *NoColorFormatter) FormatCheckStatus(pri *PullRequestItem) string {
 }
 
 func (ncf *NoColorFormatter) FormatReviewDecision(pri *PullRequestItem) string {
-	if pri.ReviewDecision == "APPROVED" {
+	if pri.ReviewDecision == reviewDecisionApproved {
 		return "✓"
 	}
 	return ""


### PR DESCRIPTION
## Summary
- Extracted the "SUCCESS"/"FAILURE"/"PENDING"/"APPROVED" magic strings scattered across `fetch.go` and `formatter.go` into named constants (`checkStatusSuccess`, `checkStatusFailure`, `checkStatusPending`, `reviewDecisionApproved`)
- Also fixed the semantically inaccurate fallback: PRs with no commit info now get a distinct `checkStatusUnknown` ("UNKNOWN") instead of being mislabeled "PENDING". This renders no check-status icon instead of the misleading hourglass, since we genuinely don't know the check state.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Manually verified a PR with no commit info gets `CheckStatus == "UNKNOWN"` and renders an empty (no icon) check status