### PR TITLE
Return nil instead of an empty slice on error in fetchPullRequests

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -113,7 +113,7 @@ func formatQueryString(org string, opts *Options) string {
 func fetchPullRequests(queryString string, limit int) ([]RepositoryItem, error) {
 	client, err := api.DefaultGraphQLClient()
 	if err != nil {
-		return []RepositoryItem{}, err
+		return nil, err
 	}
 
 	var query = searchQuery{}
@@ -123,7 +123,7 @@ func fetchPullRequests(queryString string, limit int) ([]RepositoryItem, error) 
 	}
 	err = client.Query("PullRequests", &query, variables)
 	if err != nil {
-		return []RepositoryItem{}, err
+		return nil, err
 	}
 
 	pullRequests := make([]PullRequest, 0, len(query.Nodes))


### PR DESCRIPTION
## Summary
- `fetchPullRequests` returned `[]RepositoryItem{}` on error paths; changed to `nil` to follow Go convention (callers only append/range over the result, so this is a safe no-op change)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`